### PR TITLE
airframes(4701 DEXI-3 Indoor): set RC_CRSF_PRT_CFG=0 default

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4701_dexi3_indoor
+++ b/ROMFS/px4fmu_common/init.d/airframes/4701_dexi3_indoor
@@ -89,3 +89,9 @@ param set-default EKF2_OF_QMIN 50    # lower flow-quality gate for indoor
 param set-default EKF2_GPS_CTRL 0    # no GPS indoors
 param set-default COM_ARM_WO_GPS 1   # allow arming without GPS
 param set-default SENS_FLOW_ROT 0    # UP-T201 mounting orientation
+
+# RC receiver — CRSF on the dedicated RC pad (UART7 → CONFIG_BOARD_SERIAL_RC).
+# The built-in rc_input driver auto-detects CRSF on that port; the standalone
+# CRSF driver MUST stay disabled or it races rc_input on input_rc publication
+# and channels read as all-zero / rssi=255. Caught 2026-06-04 on the dev kit.
+param set-default RC_CRSF_PRT_CFG 0


### PR DESCRIPTION
## Summary

Prevents a regression we hit on the DEXI-3 dev kit today: after a post-v1.17.0 param reset, the user set `RC_CRSF_PRT_CFG=201` (GPS1) thinking the standalone CRSF driver needed a port assignment. The standalone driver then opened GPS1 (no signal) while the built-in `rc_input` driver, which already auto-detects CRSF on the dedicated RC pad (`CONFIG_BOARD_SERIAL_RC = /dev/ttyS4`, UART7 → PE7/PE8), was effectively shadowed on `input_rc` publication. Symptom: `RC_CHANNELS` streamed at the right rate with `chancount=16 / rssi=255 / ch1..ch16 = 0`. Took most of a session to track down.

The fix is one line: `param set-default RC_CRSF_PRT_CFG 0`. The built-in rc_input driver handles CRSF on the RC pad on its own; the standalone CRSF driver should remain disabled on this airframe.

## Why `set-default` and not `set`
`set-default` keeps any explicit user-set value intact (e.g. someone who knowingly wants the standalone CRSF driver on a TELEM port for back-telemetry), but guarantees a clean `param reset` + airframe re-apply lands at the working value. This is the standard pattern in this airframe.

## Evidence from the live FC

dmesg from a working boot:
```
[rc_input] RC scan: CRSF RC input locked
```
…confirming rc_input on `/dev/ttyS4` decodes CRSF natively. No standalone CRSF driver needed for a one-way RC receiver. (If we ever want CRSF telemetry back to the radio, that requires the standalone driver on a TELEM port — different setup, document then.)

## Test plan
- [ ] Re-flash a dev kit with this airframe, do `param reset_all`, re-apply 4701, plug in CRSF receiver to the RC pad → `RC_CHANNELS` shows live PWM values.
- [ ] No regression for users who explicitly set `RC_CRSF_PRT_CFG` to a TELEM port (set-default leaves explicit values intact).