### PR TITLE
DEXI-3 H743-AIO battery: fix V_DIV + 3S Li-ion defaults

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4701_dexi3_indoor
+++ b/ROMFS/px4fmu_common/init.d/airframes/4701_dexi3_indoor
@@ -18,7 +18,12 @@
 # Comms verified on the DroneBlocks H743-AIO (board 1240) against DEXI-OS.
 
 # --- QAV250-class frame geometry + tune (DEXI-3 base) ---
-param set-default BAT1_N_CELLS 4   # TODO confirm DEXI-3 pack (QAV250 default = 4S)
+# DEXI-3 ships with a 3S Li-ion pack (confirmed 2026-06-04).
+# V_EMPTY 3.0 V/cell is the Li-ion safe-discharge floor; LiPo default of 3.2 is
+# overly conservative for Li-ion chemistry and reports "empty" with usable
+# capacity remaining. V_CHARGED stays at 4.2 V/cell (default; same as LiPo).
+param set-default BAT1_N_CELLS 3
+param set-default BAT1_V_EMPTY 3.0
 
 param set-default IMU_GYRO_CUTOFF 120
 param set-default IMU_DGYRO_CUTOFF 45

--- a/boards/droneblocks/h743-aio/init/rc.board_defaults
+++ b/boards/droneblocks/h743-aio/init/rc.board_defaults
@@ -5,7 +5,12 @@
 param set-default BAT1_A_PER_V 14.14
 param set-default BAT1_N_CELLS 4
 param set-default BAT1_V_CHARGED 4.2
-param set-default BAT1_V_DIV 21.12
+# Voltage divider — measured ratio for the H743-AIO's onboard Vbat sense.
+# Upstream MicoAir ships 21.12 (which is ~2× the actual hardware) and
+# board_config.h comments the correct value as "11.0f, measured with the
+# provided PM board". Verified 2026-06-04 against a multimeter on the
+# DroneBlocks dev kit (11.9 V actual ↔ FC reported 11.46 V with V_DIV=11.0).
+param set-default BAT1_V_DIV 11.0
 param set-default BAT1_V_EMPTY 3.2
 
 param set-default SYS_HAS_MAG 0


### PR DESCRIPTION
## Summary

Three substantive fixes to the battery monitor defaults on DEXI-3 / H743-AIO, all measured and verified live against a multimeter on the DroneBlocks dev kit (2026-06-04).

Before this PR, a freshly-flashed DEXI-3 reads any pack as **"100% remaining"** in the GCS regardless of actual state — voltage is clamped above the 4S charged threshold because the divider's wrong, and the cell count is wrong on top of that. After the PR, voltages match a multimeter (±3%) and `remaining%` tracks state of charge correctly for the 3S Li-ion pack.

## Changes

### 1. `BAT1_V_DIV`: 21.12 → 11.0  *(board-level, `rc.board_defaults`)*

Upstream MicoAir shipped `21.12`, which reports voltage at roughly 2× the actual hardware. Caught live: multimeter `11.9 V`, PX4 reported `23.215 V`. The same upstream `board_config.h` has a *commented-out* note saying the correct value is `11.0f, measured with the provided PM board`. We adopt that measured value.

Verified by writing `BAT1_V_DIV = 11.0` to the live FC: voltage dropped to `11.46 V` (within ~4% of multimeter — well within calibration tolerance).

### 2. `BAT1_N_CELLS`: 4 → 3  *(airframe-level, `4701_dexi3_indoor`)*

DEXI-3 ships with a **3S Li-ion** pack, not a 4S LiPo. The old value was inherited from the Holybro QAV250 template the airframe is based on (the airframe even carried a `# TODO confirm DEXI-3 pack` comment which is now retired).

### 3. `BAT1_V_EMPTY`: 3.2 → 3.0 V/cell  *(airframe-level)*

Li-ion can safely discharge below the LiPo 3.2 V/cell floor. 3.0 V/cell matches the chemistry; the old 3.2 left usable capacity on the table and triggered low-battery warnings earlier than needed for Li-ion.

## Why two files, not one

- `BAT1_V_DIV` is a **board** property (the divider is on the PCB) → fixed in `rc.board_defaults`. Any vehicle that ever uses this board benefits.
- `BAT1_N_CELLS` and `BAT1_V_EMPTY` are **vehicle / chemistry** properties → fixed in the `4701_dexi3_indoor` airframe. A future DroneBlocks airframe on the same board with a different battery would set its own values without re-fighting the divider.

## Note on Li-ion discharge curve

PX4's default linear V→% interpolation is less accurate for Li-ion than LiPo (Li-ion's curve has a flatter mid-range and a sharper knee near empty). `remaining%` will tend to overestimate in the middle of a flight and drop fast at the end. Mitigation: `BAT1_R_INTERNAL` calibration once we have flight data under load (PX4 measures internal resistance empirically). Out of scope for this PR — just flagging it.

## Test plan

- [x] Verified live on the dev kit at .61: `BAT1_V_DIV=11.0`, `BAT1_N_CELLS=3` → `BATTERY_STATUS` voltage `11.57 V` (multimeter 11.9 V), `remaining=65%` on a partially-drained 3S Li-ion.
- [ ] Fresh flash + `param reset_all` + 4701 airframe re-apply → voltages match multimeter out of the box, no manual calibration needed.
- [ ] Verify under load — voltage sag behavior, `BAT1_R_INTERNAL` empirical fit.

## Upstream

The `21.12 → 11.0` fix is a bug in MicoAir's upstream board defaults; worth raising a separate PR to PX4 main for `boards/micoair/h743-aio/init/rc.board_defaults`. Not in scope here.